### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 # [0.2.0]
 
 * Added visibility, and validation with package name, given an array of strings, to check if the banner is visible or not.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: version_banner
 description: A banner that shows the current version or flavour of the app
-version: 0.2.0
+version: 0.2.1
 author: Gonçalo Palma <solid.goncalo@gmail.com>
 homepage: https://github.com/Vanethos/flutter_version_banner
 issue_tracker: https://github.com/Vanethos/flutter_version_banner/issues
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  package_info: ^0.4.0+4
+  package_info: '>=0.4.0+4 <2.0.0'
 
 
 dev_dependencies:


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).